### PR TITLE
Feat: resume job from checkpoint file

### DIFF
--- a/mazepa/click_interface.py
+++ b/mazepa/click_interface.py
@@ -4,52 +4,136 @@ import click
 from mazepa.scheduler import Scheduler
 from mazepa.executor import Executor
 
+
 def click_options(cls):
-    queue = click.option('--queue_name', '-q', nargs=1,
-            type=str, default=None,
-            help="Name of the queue where the tasks will be pushed to. "
-            "For file queue, use 'fq://{path_to_shared_storage}' format."
-            "If no 'fq://' prefix is given, the queue is assumed to be SQS. "
-            "If not specified, tasks will be executed locally.")
+    queue = click.option(
+        "--queue_name",
+        "-q",
+        nargs=1,
+        type=str,
+        default=None,
+        help="Name of the queue where the tasks will be pushed to. "
+        "For file queue, use 'fq://{path_to_shared_storage}' format."
+        "If no 'fq://' prefix is given, the queue is assumed to be SQS. "
+        "If not specified, tasks will be executed locally.",
+    )
 
-    completion_queue = click.option('--completion_queue_name', nargs=1,
-            type=str, default=None,
-            help="Name of AWS SQS queue where completion of tasks will "
-            "be reported. Must be distinct from the 'queue_name'. "
-            "Providing a completion queue will speed up execution when "
-            "running workers on unreliable machines (preemptible, spot).")
+    completion_queue = click.option(
+        "--completion_queue_name",
+        nargs=1,
+        type=str,
+        default=None,
+        help="Name of AWS SQS queue where completion of tasks will "
+        "be reported. Must be distinct from the 'queue_name'. "
+        "Providing a completion queue will speed up execution when "
+        "running workers on unreliable machines (preemptible, spot).",
+    )
 
-    region = click.option('--sqs_queue_region',  nargs=1,
-            type=str, default='us-east-1',
-            help="AWS region of  SQS queues. Task queue and completion "
-            "queue must share the same region.")
+    region = click.option(
+        "--sqs_queue_region",
+        nargs=1,
+        type=str,
+        default="us-east-1",
+        help="AWS region of  SQS queues. Task queue and completion "
+        "queue must share the same region.",
+    )
 
-    return queue(completion_queue(region(cls)))
+    restart_from_checkpoint_file = click.option(
+        "--restart_from_checkpoint_file",
+        nargs=1,
+        type=str,
+        default=None,
+        help="Option to be used in case of a job interruption. Specify "
+        "path to filename where job progress is logged so that execution "
+        "can start from where it left off before the interruption.",
+    )
+
+    return queue(completion_queue(region(restart_from_checkpoint_file(cls))))
+
 
 def parse_queue_params(args):
-    queue_name = args['queue_name']
-    completion_queue_name = args['completion_queue_name']
-    queue_region = args['sqs_queue_region']
+    queue_name = args["queue_name"]
+    completion_queue_name = args["completion_queue_name"]
+    queue_region = args["sqs_queue_region"]
 
     if queue_name is not None:
         s = boto3.Session()
-        sqs_regions = s.get_available_regions('sqs')
+        sqs_regions = s.get_available_regions("sqs")
         if queue_region not in sqs_regions:
-            raise Exception(f"Invalid AWS SQS region '{queue_region}'. "
-                f"Valid AWS SQS region list: {sqs_regions}")
+            raise Exception(
+                f"Invalid AWS SQS region '{queue_region}'. "
+                f"Valid AWS SQS region list: {sqs_regions}"
+            )
 
             if queue_name is None and completion_queue_name is not None:
-                raise Exception("'completion_queue_name' can only be "
-                        "used when 'queue_name' is provided")
+                raise Exception(
+                    "'completion_queue_name' can only be "
+                    "used when 'queue_name' is provided"
+                )
     return {
-            'queue_name': queue_name,
-            'completion_queue_name': completion_queue_name,
-            'queue_region': queue_region
+        "queue_name": queue_name,
+        "completion_queue_name": completion_queue_name,
+        "queue_region": queue_region,
+    }
+
+
+def validate_jobs_dict(status_object, dict_name):
+    status_dict = status_object[dict_name]
+    if isinstance(status_dict, dict):
+        for job_number, job_info in status_dict.items():
+            if "task_batch_number" not in job_info:
+                raise Exception(
+                    f"Job {job_info} in checkpoint file must specify 'task_batch_number'"
+                )
+    else:
+        raise Exception(
+            f"{dict_name} entry in checkpoint file must be a dictionary"
+        )
+
+
+def parse_checkpoint_file(args):
+    checkpoint_file_path = args["restart_from_checkpoint_file"]
+    if checkpoint_file_path is None:
+        return {
+            "command": "",
+            "job_status": {"unfinished_jobs": {}, "finished_jobs": {}},
         }
+    else:
+        import json
+
+        with open(checkpoint_file_path) as f:
+            try:
+                status_object = json.load(f)
+            except:
+                raise Exception("Checkpoint file is not proper json")
+            if "job_status" not in status_object:
+                raise Exception("Checkpoint file missing 'job_status' object")
+            if ("unfinished_jobs" not in status_object["job_status"]) or (
+                "finished_jobs" not in status_object["job_status"]
+            ):
+                raise Exception(
+                    "Checkpoint file must contain 'unfinished_jobs' and 'finished_jobs' dicts"
+                )
+            validate_jobs_dict(status_object["job_status"], "unfinished_jobs")
+            validate_jobs_dict(status_object["job_status"], "finished_jobs")
+            return status_object
+
 
 def parse_scheduler_from_kwargs(args):
-    queue_params = parse_queue_params(args)
-    return Scheduler(**queue_params)
+    scheduler_params = parse_queue_params(args)
+    checkpoint_params = parse_checkpoint_file(args)
+    scheduler_params["job_status_object"] = checkpoint_params["job_status"]
+    scheduler_params["command"] = checkpoint_params.get("command", "")
+    scheduler_params["command_name"] = args["command_name"]
+    import sys
+
+    # If running from the command line and not restarting from a file, store the command
+    if len(sys.argv) > 1 and (
+        "command" not in scheduler_params or scheduler_params["command"] == ""
+    ):
+        scheduler_params["command"] = " ".join(sys.argv)
+    return Scheduler(**scheduler_params)
+
 
 def parse_executor_from_kwargs(args):
     queue_params = parse_queue_params(args)

--- a/mazepa/queue.py
+++ b/mazepa/queue.py
@@ -19,7 +19,7 @@ retry = tenacity.retry(
   )
 
 
-# TQ wrapper. Theretically don't have to use TQ library, but it's nice
+# TQ wrapper. Theoretically don't have to use TQ library, but it's nice
 class MazepaTaskTQ(TQRegisteredTask):
     def __init__(self, task=None,
             task_spec=None,
@@ -123,7 +123,7 @@ class Queue:
 
             if completion_queue_name is not None:
                 if self.queue_type == 'fq':
-                    raise NotImplementedError("Completion queue is not supported with sqs")
+                    raise NotImplementedError("Completion queue is not supported with file queue")
 
                 self.completion_registry = None
                 self.completion_queue = \
@@ -164,13 +164,13 @@ class Queue:
             tq_tasks = pool.map(task_constructor, mazepa_tasks)
             self.submit_tq_tasks(tq_tasks)
 
+
     @retry
     def remote_queue_is_empty(self):
         """Is our remote queue empty?
         """
         if self.queue_type == 'sqs':
             attribute_names = ['ApproximateNumberOfMessages', 'ApproximateNumberOfMessagesNotVisible']
-            is_empty = True
             for i in range(10):
                 response = self.queue_boto.get_queue_attributes(
                         QueueUrl=self.queue_url,
@@ -178,12 +178,11 @@ class Queue:
                 for a in attribute_names:
                     num_messages = int(response['Attributes'][a])
                     if num_messages > 0:
-                        is_empty = False
-                        break
+                        return False
                 if i < 9:
                     time.sleep(0.5)
 
-            return is_empty
+            return True
         elif self.queue_type == 'fq':
             return self.queue.is_empty()
         else:

--- a/mazepa/scheduler.py
+++ b/mazepa/scheduler.py
@@ -1,3 +1,6 @@
+import datetime
+import json
+import os
 import time
 import uuid
 import six
@@ -5,17 +8,60 @@ import six
 from mazepa.queue import Queue
 from mazepa.job import Job, AllJobsIndicator
 
+
 class Scheduler:
-    def __init__(self, queue_name=None, completion_queue_name=None,
-            queue_region=None, threads=16, max_task_batch=20000):
-        self.queue = Queue(queue_name=queue_name,
-                completion_queue_name=completion_queue_name,
-                queue_region=queue_region,
-                threads=threads)
+    def __init__(
+        self,
+        queue_name=None,
+        completion_queue_name=None,
+        queue_region=None,
+        threads=16,
+        max_task_batch=20000,
+        job_status_object=None,
+        command="",
+        command_name=None,
+    ):
+        self.queue = Queue(
+            queue_name=queue_name,
+            completion_queue_name=completion_queue_name,
+            queue_region=queue_region,
+            threads=threads,
+        )
+
+        self._job_status_object = job_status_object
 
         self.unfinished_jobs = {}
-        self.finished_jobs   = {}
+        self.finished_jobs = {}
         self.max_task_batch = max_task_batch
+
+        # when we restart jobs from a checkpoint file, we can only rely on the order the jobs were
+        # submitted to determine which job is at which step (because user-specified names for jobs are optional).
+        # therefore, we keep track of how many jobs have been submitted so far.
+        self._current_job_counter = 0
+
+        # where to store the checkpoint file for the current run.
+        home_dir = os.path.expanduser("~")
+        mazepa_dir = os.path.join(home_dir, ".mazepa")
+        datetime_string = (
+            datetime.datetime.now()
+            .isoformat(timespec="seconds")
+            .replace("-", "_")
+            .replace(":", "_")
+        )
+        if command_name is None:
+            checkpoint_filename = (
+                f"job_checkpoints/job_checkpoint_{datetime_string}.json"
+            )
+        else:
+            checkpoint_filename = f"job_checkpoints/{command_name}/job_checkpoint_{datetime_string}.json"
+        self._job_check_point_filepath = os.path.join(
+            mazepa_dir, checkpoint_filename
+        )
+        os.makedirs(
+            os.path.dirname(self._job_check_point_filepath), exist_ok=True
+        )
+
+        self._command = command
 
     def all_jobs_finished(self):
         return bool(self.unfinished_jobs)
@@ -25,7 +71,9 @@ class Scheduler:
         if jobs_ready is not None:
             self.submit_jobs(jobs_ready)
         else:
-            unsubmitted_jobs = self.queue.get_unsubmitted_jobs(self.unfinished_jobs)
+            unsubmitted_jobs = self.queue.get_unsubmitted_jobs(
+                self.unfinished_jobs
+            )
             if unsubmitted_jobs is not None:
                 self.submit_jobs(unsubmitted_jobs)
 
@@ -43,22 +91,28 @@ class Scheduler:
         tasks = []
         jobs_just_finished = []
 
-        for job_name, job in six.iteritems(self.unfinished_jobs):
+        for job_name, job_object in six.iteritems(self.unfinished_jobs):
+            job_object["metadata"]["task_batch_number"] = (
+                job_object["metadata"]["task_batch_number"] + 1
+            )
+            job = job_object["job"]
             this_job_tasks = []
             # if this job is flagged for execution
-            if isinstance(jobs_spec, AllJobsIndicator) or \
-                    job_name in jobs_spec:
+            if isinstance(jobs_spec, AllJobsIndicator) or job_name in jobs_spec:
                 if isinstance(job, Job):
                     this_job_tasks = job.get_task_batch()
-                    print ("Got {} tasks from job '{}'".format(len(this_job_tasks),
-                            job_name))
+                    print(
+                        "Got {} tasks from job '{}'".format(
+                            len(this_job_tasks), job_name
+                        )
+                    )
                     if this_job_tasks == []:
                         jobs_just_finished.append(job_name)
                 else:
                     try:
                         this_job_tasks = job()
                     except StopIteration:
-                        print ("Job '{}' is done!")
+                        print("Job '{}' is done!")
                         jobs_just_finished.append(job_name)
                 for t in this_job_tasks:
                     t.job_name = job_name
@@ -69,43 +123,146 @@ class Scheduler:
 
         # Move finished jobs to finished dict
         for job_name in jobs_just_finished:
-            print ("Flagging job as FINISHED: '{}'".format(job_name))
+            print("Flagging job as FINISHED: '{}'".format(job_name))
             self.finished_jobs[job_name] = self.unfinished_jobs[job_name]
             del self.unfinished_jobs[job_name]
 
+        self._write_job_checkpoint_file()
+
         if len(tasks) > 0:
-            print ("Scheduling {} tasks..".format(len(tasks)))
+            print("Scheduling {} tasks..".format(len(tasks)))
             self.queue.submit_mazepa_tasks(tasks)
         else:
-            print ("No tasks to submit!")
-
+            print("No tasks to submit!")
 
     def register_job(self, job, job_name=None):
-        '''
+        """
         job must be either an istance of type mazepa.Job
         or a simple generator
-        '''
+        """
         if not isinstance(job, Job):
-           if not inspect.isgeneratorfunction(job) and \
-                   not inspect.isgenerator(job):
-                       raise Exception("Registering job that is \
+            if not inspect.isgeneratorfunction(job) and not inspect.isgenerator(
+                job
+            ):
+                raise Exception(
+                    "Registering job that is \
                                neither Mazepa job nor a generator is\
                                not supported. Submitted job type: {}".format(
-                                   type(job)
-                                   ))
+                        type(job)
+                    )
+                )
 
         if job_name is None:
             job_name = uuid.uuid1()
-            while job_name in self.unfinished_jobs:
+            while (
+                job_name in self.unfinished_jobs
+                or job_name in self.finished_jobs
+            ):
                 job_name = uuid.uuid1()
         else:
-            if job_name in self.unfinished_jobs:
-                raise Exception('Unable to register task "{}": \
-                        task with name "{}" is already registerd'.format(job_name, job_name))
+            if (
+                job_name in self.unfinished_jobs
+                or job_name in self.finished_jobs
+            ):
+                raise Exception(
+                    'Unable to register task "{}": \
+                        task with name "{}" is already registered'.format(
+                        job_name, job_name
+                    )
+                )
 
-        self.unfinished_jobs[job_name] = job
+        self._set_job_to_checkpoint(job, job_name)
 
         return job_name
 
     def unregister_job(self, job_name):
-        del self.unfinished_jobs[job_name]
+        if job_name in self.unfinished_jobs:
+            del self.unfinished_jobs[job_name]
+
+    def _set_job_to_checkpoint(self, job, job_name):
+        if (
+            str(self._current_job_counter)
+            in self._job_status_object["unfinished_jobs"]
+        ):
+            task_batches_completed = self._job_status_object["unfinished_jobs"][
+                str(self._current_job_counter)
+            ]["task_batch_number"]
+            self.unfinished_jobs[job_name] = {
+                "job": job,
+                "metadata": {
+                    "job_number": self._current_job_counter,
+                    "task_batch_number": task_batches_completed,
+                },
+            }
+            # fast-forward job to batch specified by checkpoint file
+            for i in range(task_batches_completed):
+                job_finished = False
+                if isinstance(job, Job):
+                    this_job_tasks = job.get_task_batch()
+                    if this_job_tasks == []:
+                        job_finished = True
+                else:
+                    try:
+                        this_job_tasks = job()
+                    except StopIteration:
+                        job_finished = True
+                if job_finished:
+                    raise Exception(
+                        f"Checkpoint file says job {job_name} on task batch {task_batches_completed}, but job only has {i} task batches"
+                    )
+        elif (
+            str(self._current_job_counter)
+            in self._job_status_object["finished_jobs"]
+        ):
+            task_batches_completed = self._job_status_object["finished_jobs"][
+                str(self._current_job_counter)
+            ]["task_batch_number"]
+            self.finished_jobs[job_name] = {
+                "job": job,
+                "metadata": {
+                    "job_number": self._current_job_counter,
+                    "task_batch_number": task_batches_completed,
+                },
+            }
+            print(
+                "Job '{}' marked as completed in status file".format(job_name)
+            )
+        else:
+            self.unfinished_jobs[job_name] = {
+                "job": job,
+                "metadata": {
+                    "job_number": self._current_job_counter,
+                    "task_batch_number": 0,
+                },
+            }
+        # increment counter for next job to register
+        self._current_job_counter = self._current_job_counter + 1
+
+    def _write_job_checkpoint_file(self):
+        unfinished_jobs_object = {}
+        finished_jobs_object = {}
+        for job_name, job_object in self.unfinished_jobs.items():
+            job_number = job_object["metadata"]["job_number"]
+            unfinished_jobs_object[job_number] = {
+                "task_batch_number": job_object["metadata"][
+                    "task_batch_number"
+                ],
+                "job_name": job_name,
+            }
+        for job_name, job_object in self.finished_jobs.items():
+            job_number = job_object["metadata"]["job_number"]
+            finished_jobs_object[job_number] = {
+                "task_batch_number": job_object["metadata"][
+                    "task_batch_number"
+                ],
+                "job_name": job_name,
+            }
+        job_checkpoint_object = {
+            "command": self._command,
+            "job_status": {
+                "unfinished_jobs": unfinished_jobs_object,
+                "finished_jobs": finished_jobs_object,
+            },
+        }
+        with open(self._job_check_point_filepath, "w") as f:
+            f.write(json.dumps(job_checkpoint_object, indent=4))


### PR DESCRIPTION
Add option `--restart_from_checkpoint_file` that takes a path to a local JSON file containing information about a past interrupted run (e.g. corgie align command). The file specifies which barrier/task batch each job of the run last completed before the job was interrupted. The scheduler then starts each job from its respective checkpoint.

The scheduler now also automatically creates and overwrites a job checkpoint file, in case the job is interrupted. The checkpoint files are stored in `~/.mazepa/job_checkpoints`. Every time the scheduler submits the next batch of tasks, it overwrites the checkpoint file associated with the current run. JSON is used because keeping the files human-readable is nice, and the files are small, so there is not much downside.

Example job checkpoint file:
```
{
    "command": "/home/manuel/NewVirtualenvs/Corgie/bin/corgie align --src_layer_spec {...",
    "job_status": {
        "unfinished_jobs": {
            "0": {
                "task_batch_number": 7,
                "job_name": "Forward Align Block 5099->5107 [MIP 0] [0, 278400], [0, 130944], [5099, 5107]"
            },
            "1": {
                "task_batch_number": 7,
                "job_name": "Forward Align Block 5104->5112 [MIP 0] [0, 278400], [0, 130944], [5104, 5112]"
            }
        },
        "finished_jobs": {}
    }
}```